### PR TITLE
music decoration fix

### DIFF
--- a/.config/awesome/layout/deco/music.lua
+++ b/.config/awesome/layout/deco/music.lua
@@ -138,7 +138,7 @@ local updater = function(widget, stdout, _, _, _)
   elseif mpdstatus == "paused" then
     toggle_icon.image = gears.color.recolor_image(os.getenv("HOME") .. "/.config/awesome/images/mpd/play.png", beautiful.fg_color)
     widget.value = tonumber(mpdpercent/100)
-  else 
+  else
     toggle_icon.image = gears.color.recolor_image(os.getenv("HOME") .. "/.config/awesome/images/mpd/play.png", beautiful.fg_color)
   end
 end
@@ -275,7 +275,10 @@ end
 ruled.client.connect_signal("request::rules", function()
     ruled.client.append_rule {
         id = "music",
-        rule = {instance = "music"},
+        rule_any = {
+            class = {"music"},
+            instance = {"music"}
+        },
         callback = music_init
     }
 end)


### PR DESCRIPTION
All terminals handle class differently. add decorations to both class and instance.

for example.
if you run ``alacritty  --class music``
you'll get, Instance = music and class = music

and if you run ``st -c music``
you'll get, Instance = st and class = music (You won't get music decorations in this case.)

this pull request fixes the issue and adds decorations to both class and instance.

This is not a part of pull request but.
throughout the configurations you're using ``os.getenv("HOME")``
it's much better to define it as an variable than calling on function over and over again.
like this  ``home = os.getenv("HOME")`` or  ``home = "/home/*user*"``  and now you can simply use home wherever you want.
because  `` home .. "/.config" `` is much better then `` os.getenv("HOME") .. "/.config" ``
